### PR TITLE
ブロックのレベルを表す色を変更

### DIFF
--- a/src/renderer/styleConfig/colors.ts
+++ b/src/renderer/styleConfig/colors.ts
@@ -10,7 +10,7 @@ const colors = {
     FIRST: '#06A9C4',
     SECOND: '#CFF8FF',
     THIRD: '#CFF8FF',
-    LEVEL: ['#F2FDFF', '#66DDF2', '#5BC6D9', '#50AFBF', '#4697A6', '#3B808C'],
+    LEVEL: ['#F2FDFF', '#66DDF2', '#50AFBF', '#3B808C', '#255159', '#102326'],
   },
   red: {
     DEFAULT: '#F76874'


### PR DESCRIPTION
## 問題
ブロックのレベル別の色はユニバーサルデザインを考慮し明度差のみによって違いを表現していた。
しかし各レベルの明度差はHSVにおいて10であり差が明確ではなかった。
## 解決方法
各レベルの明度差を20にすることでより明確な差をつけた。
