### PR TITLE
Make SideMenu component and replace a part of AddContent with the component

### DIFF
--- a/src/renderer/components/SideMenu/index.tsx
+++ b/src/renderer/components/SideMenu/index.tsx
@@ -5,7 +5,7 @@ import { colors } from '~/styleConfig';
 type SideMenuProps = {
   isOpen: boolean;
   onClose: () => void;
-  children: () => JSX.Element;
+  children: JSX.Element;
 };
 
 export const SideMenu: VFC<SideMenuProps> = ({ 

--- a/src/renderer/components/SideMenu/index.tsx
+++ b/src/renderer/components/SideMenu/index.tsx
@@ -1,0 +1,47 @@
+import { VFC } from 'react';
+
+import { colors } from '~/styleConfig';
+
+type SideMenuProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  children: () => JSX.Element;
+};
+
+export const SideMenu: VFC<SideMenuProps> = ({ 
+  isOpen,
+  onClose,
+  children,
+  }) => {
+  return (
+    <aside css={{
+      position: 'relative',
+      width: isOpen ? '250px' : '0px',
+      height: '100%',
+      zIndex: 1,
+      transitionProperty: 'width',
+      transitionDuration: '.5s',
+      transitionTimingFunction: 'ease',
+    }}>
+      <div css={{ 
+          display: isOpen ? 'block' : 'none',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          paddingLeft: '24px',
+          borderLeft: `1px solid ${colors.cyan.DEFAULT}`,
+          height: '100%',
+        }}>
+      <button 
+        css={{
+          width: '100%',
+          display: 'block',
+          textAlign: 'right',
+          marginBottom: '16px',
+        }}
+        onClick={onClose}>X</button>
+        {children}
+      </div>
+    </aside>
+  );
+};

--- a/src/renderer/components/index.ts
+++ b/src/renderer/components/index.ts
@@ -28,3 +28,4 @@ export * from './ModalToUpdateLogTitle';
 export * from './ControlTagSelectionWithSearch';
 export * from './ControlSelectionOfBlockLevels';
 export * from './ControlSelectionOfContentNameWithSearch';
+export * from './SideMenu';

--- a/src/renderer/pages/Contents/components/AddContent/index.tsx
+++ b/src/renderer/pages/Contents/components/AddContent/index.tsx
@@ -1,8 +1,9 @@
 import { VFC } from 'react';
 
-import { colors } from '~/styleConfig';
-
-import { AddContentForm } from '~/components';
+import { 
+  AddContentForm,
+  SideMenu,
+  } from '~/components';
 
 
 type AddContentProps = {
@@ -15,34 +16,10 @@ export const AddContent: VFC<AddContentProps> = ({
   onClose,
   }) => {
   return (
-    <div css={{
-      position: 'relative',
-      width: isOpen ? '250px' : '0px',
-      height: '100%',
-      zIndex: 1,
-      transitionProperty: 'width',
-      transitionDuration: '.5s',
-      transitionTimingFunction: 'ease',
-    }}>
-      <div css={{ 
-          display: isOpen ? 'block' : 'none',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          paddingLeft: '24px',
-          borderLeft: `1px solid ${colors.cyan.DEFAULT}`,
-          height: '100%',
-        }}>
-      <button 
-        css={{
-          width: '100%',
-          display: 'block',
-          textAlign: 'right',
-          marginBottom: '16px',
-        }}
-        onClick={onClose}>X</button>
-        <AddContentForm />
-      </div>
-    </div>
+    <SideMenu 
+      isOpen={isOpen}
+      onClose={onClose}>
+      <AddContentForm />
+    </SideMenu>
   );
 };


### PR DESCRIPTION
In the previous implementation, AddContent depended on the details of the way of layout. So to decouple the dependency, I made SideMenu component and re-wrote AddContent with SideMenu. 

In this way, we become able to change the layout of AddContent more easily.
